### PR TITLE
Add JS build step to lint CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,5 +47,8 @@ jobs:
     - name: Install Node dependencies
       run: pnpm install --frozen-lockfile
 
+    - name: JS build
+      run: pnpm run build
+
     - name: JS lint
       run: pnpm run lint:js


### PR DESCRIPTION
## Summary
- Adds `pnpm run build` before `pnpm run lint:js` in the lint workflow
- Ensures JS build breakages are caught in CI, not just lint errors