### PR TITLE
Add configurable vision model setting

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -41,7 +41,7 @@ class Admin {
 	public function rename_new_file( array $file ) {
 		$path = $file['tmp_name'];
 
-		$wrapper = new Openai_Wrapper( $this->settings->get_openai_api_key(), $this->settings->get_dell_e_version() );
+		$wrapper = new Openai_Wrapper( $this->settings->get_openai_api_key(), $this->settings->get_dell_e_version(), $this->settings->get_vision_model() );
 		try {
 			$image = new Image();
 			if ( $image->is_image( $path ) ) {
@@ -77,7 +77,7 @@ class Admin {
 		$uploads = wp_get_upload_dir();
 		$file    = $uploads['basedir'] . '/' . $data['file'];
 
-		$wrapper = new Openai_Wrapper( $this->settings->get_openai_api_key(), $this->settings->get_dell_e_version() );
+		$wrapper = new Openai_Wrapper( $this->settings->get_openai_api_key(), $this->settings->get_dell_e_version(), $this->settings->get_vision_model() );
 		try {
 			$image = new Image();
 			if ( $image->is_image( $file ) ) {

--- a/src/Alt_Text_Rest_Api.php
+++ b/src/Alt_Text_Rest_Api.php
@@ -49,7 +49,7 @@ class Alt_Text_Rest_Api {
 			return new WP_REST_Response( [ 'error' => 'OpenAI API key not found' ], 404 );
 		}
 
-		$open_ai_wrapper = new Openai_Wrapper( $this->setting->get_openai_api_key(), $this->setting->get_dell_e_version() );
+		$open_ai_wrapper = new Openai_Wrapper( $this->setting->get_openai_api_key(), $this->setting->get_dell_e_version(), $this->setting->get_vision_model() );
 
 		$post_id = $request->get_param( 'mediaId' );
 

--- a/src/Dalle_Image_Generator.php
+++ b/src/Dalle_Image_Generator.php
@@ -52,7 +52,7 @@ class Dalle_Image_Generator {
 		$prompt       = $request->get_param( 'prompt' );
 
 		try {
-			$wrapper       = new Openai_Wrapper( $this->setting->get_openai_api_key(), $this->setting->get_dell_e_version() );
+			$wrapper       = new Openai_Wrapper( $this->setting->get_openai_api_key(), $this->setting->get_dell_e_version(), $this->setting->get_vision_model() );
 			$url           = $wrapper->generate_image( $prompt, $post_title, $post_content );
 			$attachment_id = $this->save_image_as_attachment( $url );
 		} catch ( \Exception $e ) {

--- a/src/Generate_Alt_Text_Cli.php
+++ b/src/Generate_Alt_Text_Cli.php
@@ -58,7 +58,7 @@ class Generate_Alt_Text_Cli {
 		$attachment_ids_chunks = array_chunk( $attachment_ids, 50 );
 		unset( $attachment_ids, $query );
 
-		$open_ai_wrapper = new Openai_Wrapper( $setting->get_openai_api_key(), $setting->get_dell_e_version() );
+		$open_ai_wrapper = new Openai_Wrapper( $setting->get_openai_api_key(), $setting->get_dell_e_version(), $setting->get_vision_model() );
 
 		$file_path                = new File_Path( $use );
 		$generated_alt_text_count = 0;

--- a/src/Openai_Wrapper.php
+++ b/src/Openai_Wrapper.php
@@ -7,10 +7,12 @@ class Openai_Wrapper {
 
 	public string $dall_e_version;
 	private string $openai_api_key;
+	private string $vision_model;
 
-	public function __construct( $openai_api_key, $dall_e_version ) {
+	public function __construct( $openai_api_key, $dall_e_version, $vision_model = 'gpt-4.1-mini' ) {
 		$this->openai_api_key = $openai_api_key;
 		$this->dall_e_version = $dall_e_version;
+		$this->vision_model   = $vision_model;
 	}
 
 	public function get_filename( string $path ): string {
@@ -42,7 +44,7 @@ class Openai_Wrapper {
 		}
 
 		$data = [
-			'model'                 => 'gpt-4.1-mini',
+			'model'                 => $this->vision_model,
 			'messages'              => [
 				[
 					'role'    => 'user',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -15,6 +15,8 @@ class Settings {
 
 	public string $dell_e_version;
 
+	public string $vision_model;
+
 	const RENAME_NEW_FILE = 'rename_new_file';
 
 	const OPENAI_API_KEY = 'better_file_name_api_key';
@@ -25,6 +27,17 @@ class Settings {
 
 	const DELL_E_VERSION = 'better_file_name_dell_e_version';
 
+	const VISION_MODEL = 'better_file_name_vision_model';
+
+	const VISION_MODEL_DEFAULT = 'gpt-4.1-mini';
+
+	const VISION_MODELS = [
+		'gpt-4.1-mini' => 'GPT-4.1 Mini (Recommended)',
+		'gpt-4.1-nano' => 'GPT-4.1 Nano (Cheapest)',
+		'gpt-4o-mini'  => 'GPT-4o Mini',
+		'gpt-4.1'      => 'GPT-4.1 (Most capable)',
+	];
+
 	public function __construct() {
 
 		$this->should_rename_file       = (bool) get_option( self::RENAME_NEW_FILE, true );
@@ -32,6 +45,7 @@ class Settings {
 		$this->should_generate_alt_text = (bool) get_option( self::ALT_TEXT, true );
 		$this->dell_e_integration       = (bool) get_option( self::DELL_E_INTEGRATION, true );
 		$this->dell_e_version           = get_option( self::DELL_E_VERSION, 'dall-e-2' );
+		$this->vision_model             = get_option( self::VISION_MODEL, self::VISION_MODEL_DEFAULT );
 
 		add_action( 'admin_menu', [ $this, 'add_settings_page' ] );
 		add_action( 'admin_init', [ $this, 'register_settings' ] );
@@ -153,6 +167,26 @@ class Settings {
 				'label_for' => self::OPENAI_API_KEY,
 			]
 		);
+		register_setting(
+			'better_file_name_settings_group',
+			self::VISION_MODEL,
+			[
+				'sanitize_callback' => fn( $v ) => array_key_exists( $v, self::VISION_MODELS ) ? $v : self::VISION_MODEL_DEFAULT,
+			]
+		);
+		add_settings_field(
+			self::VISION_MODEL,
+			esc_html__( 'Vision Model', 'better-file-name' ),
+			[
+				$this,
+				'vision_model_dropdown_callback',
+			],
+			'better_file_name_settings',
+			$section_api,
+			[
+				'label_for' => self::VISION_MODEL,
+			]
+		);
 	}
 
 	public function rename_new_file_callback(): void {
@@ -212,5 +246,21 @@ class Settings {
 
 	public function get_dell_e_version(): string {
 		return $this->dell_e_version;
+	}
+
+	public function get_vision_model(): string {
+		return $this->vision_model;
+	}
+
+	public function vision_model_dropdown_callback(): void {
+		?>
+		<select name="<?php echo esc_attr( self::VISION_MODEL ); ?>"
+				id="<?php echo esc_attr( self::VISION_MODEL ); ?>">
+			<?php foreach ( self::VISION_MODELS as $key => $label ) : ?>
+				<option
+					value="<?php echo esc_attr( $key ); ?>" <?php selected( $this->vision_model, $key ); ?>><?php echo esc_html( $label ); ?></option>
+			<?php endforeach; ?>
+		</select>
+		<?php
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a **Vision Model** dropdown to the plugin Settings page, allowing users to choose between `gpt-4.1-mini` (default), `gpt-4.1-nano`, `gpt-4o-mini`, and `gpt-4.1`
- Replaces the hardcoded `gpt-4.1-mini` model in `Openai_Wrapper::request()` with the configurable `$this->vision_model` property
- Updates all 4 `Openai_Wrapper` instantiation sites (`Admin`, `Alt_Text_Rest_Api`, `Dalle_Image_Generator`, `Generate_Alt_Text_Cli`) to pass the configured vision model from Settings

## Details

The vision model was previously hardcoded to `gpt-4.1-mini`. This change gives users flexibility to choose a model based on their cost/quality tradeoff:

| Model | Description |
|-------|-------------|
| `gpt-4.1-mini` | Recommended default, good balance of quality and cost |
| `gpt-4.1-nano` | Cheapest option for high-volume usage |
| `gpt-4o-mini` | Alternative mini model |
| `gpt-4.1` | Most capable, highest quality output |

The setting includes a sanitize callback that validates against the allowed models list and falls back to the default if an invalid value is submitted.