### PR TITLE
Replace deprecated DALL-E with gpt-image-1 and async generation via Action Scheduler

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,5 @@
 {
 	"core": null,
 	"phpVersion": "8.4",
-	"plugins": [
-		"."
-	]
+	"plugins": [ "." ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,14 @@ WordPress plugin that renames uploaded files and generates alt text using OpenAI
 
 ## Architecture
 
-- **Language:** PHP 8.1+ (backend), JavaScript/JSX (frontend, WordPress block editor)
-- **Type:** WordPress plugin (`wordpress-plugin` composer type)
-- **Namespace:** `Better_File_Name_Ai\` (PSR-4 autoloaded from `src/`)
-- **Entry point:** `better-file-name.php` (plugin bootstrap)
-- **PHP source:** `src/` (8 classes: Admin, Settings, Openai_Wrapper, Image, File_Path, Alt_Text_Rest_Api, Dalle_Image_Generator, Generate_Alt_Text_Cli)
-- **JS source:** `js/` (index.js, media-alt-text.js) built with `@wordpress/scripts` into `build/`
-- **Tests:** `tests/` (PHPUnit with WordPress test framework)
-- **Text domain:** `better-file-name`
+-   **Language:** PHP 8.1+ (backend), JavaScript/JSX (frontend, WordPress block editor)
+-   **Type:** WordPress plugin (`wordpress-plugin` composer type)
+-   **Namespace:** `Better_File_Name_Ai\` (PSR-4 autoloaded from `src/`)
+-   **Entry point:** `better-file-name.php` (plugin bootstrap)
+-   **PHP source:** `src/` (8 classes: Admin, Settings, Openai_Wrapper, Image, File_Path, Alt_Text_Rest_Api, Dalle_Image_Generator, Generate_Alt_Text_Cli)
+-   **JS source:** `js/` (index.js, media-alt-text.js) built with `@wordpress/scripts` into `build/`
+-   **Tests:** `tests/` (PHPUnit with WordPress test framework)
+-   **Text domain:** `better-file-name`
 
 ## Build & Dev Commands
 
@@ -74,92 +74,101 @@ Test files live in `tests/`, prefixed with `test-` and suffixed with `.php`. The
 ## Code Style - PHP
 
 ### Standards & Tooling
-- **PHPCS** with WordPress Coding Standards (WPCS 3.x) via `.phpcs.xml.dist`
-- **PHPStan** level 4 with `szepeviktor/phpstan-wordpress` extension
-- PHP 8.1+ required; minimum WordPress 6.0
+
+-   **PHPCS** with WordPress Coding Standards (WPCS 3.x) via `.phpcs.xml.dist`
+-   **PHPStan** level 4 with `szepeviktor/phpstan-wordpress` extension
+-   PHP 8.1+ required; minimum WordPress 6.0
 
 ### Formatting
-- **Indentation:** Tabs (size 4) for PHP files, spaces (size 2) for JSON/YAML
-- **Line endings:** LF (Unix-style)
-- **Final newline:** Always insert
-- **Trailing whitespace:** Always trim
-- Every PHP file starts with `<?php` followed by `declare( strict_types=1 );`
+
+-   **Indentation:** Tabs (size 4) for PHP files, spaces (size 2) for JSON/YAML
+-   **Line endings:** LF (Unix-style)
+-   **Final newline:** Always insert
+-   **Trailing whitespace:** Always trim
+-   Every PHP file starts with `<?php` followed by `declare( strict_types=1 );`
 
 ### Naming Conventions
-- **Namespace:** `Better_File_Name_Ai\` for all classes in `src/`
-- **Classes:** `Upper_Snake_Case` (e.g., `Openai_Wrapper`, `Alt_Text_Rest_Api`, `File_Path`)
-- **Methods/functions:** `snake_case` (e.g., `get_filename`, `resize_image`, `register_routes`)
-- **Constants:** `UPPER_SNAKE_CASE` (e.g., `OPENAI_API_KEY`, `RENAME_NEW_FILE`)
-- **Variables:** `$snake_case` (e.g., `$post_id`, `$open_ai_wrapper`, `$attachment_ids`)
-- **Global prefixes:** All globals must use `Better_File_Name_Ai` or `better_file_name` prefix (enforced by PHPCS)
-- **Hooks/filters:** Use array callable syntax `[ $this, 'method_name' ]` or first-class callable `$this->method( ... )`
+
+-   **Namespace:** `Better_File_Name_Ai\` for all classes in `src/`
+-   **Classes:** `Upper_Snake_Case` (e.g., `Openai_Wrapper`, `Alt_Text_Rest_Api`, `File_Path`)
+-   **Methods/functions:** `snake_case` (e.g., `get_filename`, `resize_image`, `register_routes`)
+-   **Constants:** `UPPER_SNAKE_CASE` (e.g., `OPENAI_API_KEY`, `RENAME_NEW_FILE`)
+-   **Variables:** `$snake_case` (e.g., `$post_id`, `$open_ai_wrapper`, `$attachment_ids`)
+-   **Global prefixes:** All globals must use `Better_File_Name_Ai` or `better_file_name` prefix (enforced by PHPCS)
+-   **Hooks/filters:** Use array callable syntax `[ $this, 'method_name' ]` or first-class callable `$this->method( ... )`
 
 ### Type Declarations
-- Use `declare( strict_types=1 )` in every PHP file
-- Type-hint method parameters and return types (`:void`, `:bool`, `:string`, `:array`, `:?string`)
-- Use typed class properties (`public bool $should_rename_file`, `private string $openai_api_key`)
-- Use PHP 8.1 features: `readonly` properties, first-class callables (`$this->method(...)`)
+
+-   Use `declare( strict_types=1 )` in every PHP file
+-   Type-hint method parameters and return types (`:void`, `:bool`, `:string`, `:array`, `:?string`)
+-   Use typed class properties (`public bool $should_rename_file`, `private string $openai_api_key`)
+-   Use PHP 8.1 features: `readonly` properties, first-class callables (`$this->method(...)`)
 
 ### WordPress Patterns
-- Use WordPress HTTP API (`wp_remote_request`, `wp_remote_post`) instead of cURL
-- Use `wp_json_encode()` instead of `json_encode()`
-- Escape all output: `esc_html()`, `esc_attr()`, `esc_html__()`, `wp_kses()`
-- Use `__()` / `esc_html__()` with text domain `better-file-name` for all translatable strings
-- Settings API for options: `get_option()`, `register_setting()`, `add_settings_field()`
-- REST API: `register_rest_route()` with `permission_callback` and `validate_callback`
-- Check `defined( 'ABSPATH' )` at entry point; check `WP_IMPORTING` / `WP_CLI` as needed
+
+-   Use WordPress HTTP API (`wp_remote_request`, `wp_remote_post`) instead of cURL
+-   Use `wp_json_encode()` instead of `json_encode()`
+-   Escape all output: `esc_html()`, `esc_attr()`, `esc_html__()`, `wp_kses()`
+-   Use `__()` / `esc_html__()` with text domain `better-file-name` for all translatable strings
+-   Settings API for options: `get_option()`, `register_setting()`, `add_settings_field()`
+-   REST API: `register_rest_route()` with `permission_callback` and `validate_callback`
+-   Check `defined( 'ABSPATH' )` at entry point; check `WP_IMPORTING` / `WP_CLI` as needed
 
 ### Error Handling
-- Wrap OpenAI API calls in `try/catch` blocks catching `\Exception`
-- Use `error_log()` for non-fatal logging (with phpcs:ignore comment)
-- Throw `\Exception` with `esc_html__()` messages for critical failures
-- Check `is_wp_error()` on all WordPress API responses before using them
-- REST endpoints return `WP_REST_Response` with appropriate HTTP status codes (200, 404, 500)
+
+-   Wrap OpenAI API calls in `try/catch` blocks catching `\Exception`
+-   Use `error_log()` for non-fatal logging (with phpcs:ignore comment)
+-   Throw `\Exception` with `esc_html__()` messages for critical failures
+-   Check `is_wp_error()` on all WordPress API responses before using them
+-   REST endpoints return `WP_REST_Response` with appropriate HTTP status codes (200, 404, 500)
 
 ### PHPCS Exclusions (already configured)
-- `WordPress.Files.FileName.InvalidClassFileName` - PSR-4 autoloading
-- `WordPress.Files.FileName.NotHyphenatedLowercase` - PSR-4 autoloading
-- `WordPress.PHP.YodaConditions.NotYoda` - Non-Yoda comparisons allowed
-- `Universal.Arrays.DisallowShortArraySyntax.Found` - Short array syntax `[]` is used
-- File/class/function/variable comment sniffs are relaxed
+
+-   `WordPress.Files.FileName.InvalidClassFileName` - PSR-4 autoloading
+-   `WordPress.Files.FileName.NotHyphenatedLowercase` - PSR-4 autoloading
+-   `WordPress.PHP.YodaConditions.NotYoda` - Non-Yoda comparisons allowed
+-   `Universal.Arrays.DisallowShortArraySyntax.Found` - Short array syntax `[]` is used
+-   File/class/function/variable comment sniffs are relaxed
 
 ## Code Style - JavaScript
 
 ### Standards & Tooling
-- **@wordpress/scripts** (v26.19) for build, lint, and format
-- Lint with `wp-scripts lint-js` (ESLint with WordPress config)
-- Format with `wp-scripts format`
+
+-   **@wordpress/scripts** (v26.19) for build, lint, and format
+-   Lint with `wp-scripts lint-js` (ESLint with WordPress config)
+-   Format with `wp-scripts format`
 
 ### Patterns
-- WordPress imports: `@wordpress/components`, `@wordpress/data`, `@wordpress/element`, `@wordpress/hooks`, `@wordpress/i18n`, `@wordpress/api-fetch`, `@wordpress/dom-ready`
-- Use `__()` from `@wordpress/i18n` with text domain `better-file-name`
-- JSX for React components (block editor integrations)
-- Use `useState` from `@wordpress/element` (not direct React import)
-- Use `apiFetch` from `@wordpress/api-fetch` for REST calls in editor context
-- Use native `fetch` for media library context (with `X-WP-Nonce` header)
-- async/await for API calls with try/catch/finally
-- WordPress hooks: `addFilter` from `@wordpress/hooks` for editor extension points
+
+-   WordPress imports: `@wordpress/components`, `@wordpress/data`, `@wordpress/element`, `@wordpress/hooks`, `@wordpress/i18n`, `@wordpress/api-fetch`, `@wordpress/dom-ready`
+-   Use `__()` from `@wordpress/i18n` with text domain `better-file-name`
+-   JSX for React components (block editor integrations)
+-   Use `useState` from `@wordpress/element` (not direct React import)
+-   Use `apiFetch` from `@wordpress/api-fetch` for REST calls in editor context
+-   Use native `fetch` for media library context (with `X-WP-Nonce` header)
+-   async/await for API calls with try/catch/finally
+-   WordPress hooks: `addFilter` from `@wordpress/hooks` for editor extension points
 
 ## CI/CD
 
-- **GitHub Actions** on push/PR to `main`:
-  - `composer lint` (PHPCS + PHPStan)
-  - `npm run lint:js`
-- **Deploy** on GitHub release: builds and deploys to WordPress.org SVN
-- Legacy `.travis.yml` exists but CI runs on GitHub Actions
+-   **GitHub Actions** on push/PR to `main`:
+    -   `composer lint` (PHPCS + PHPStan)
+    -   `npm run lint:js`
+-   **Deploy** on GitHub release: builds and deploys to WordPress.org SVN
+-   Legacy `.travis.yml` exists but CI runs on GitHub Actions
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `better-file-name.php` | Plugin entry point, bootstraps all classes |
-| `src/Settings.php` | WordPress Settings API integration, option management |
-| `src/Admin.php` | Hook registration, file rename on upload, alt text on attachment |
-| `src/Openai_Wrapper.php` | OpenAI API communication (GPT-4 Vision, DALL-E) |
-| `src/Image.php` | Image validation and resizing via WP image editor |
-| `src/File_Path.php` | Resolves attachment file paths (local vs production) |
-| `src/Alt_Text_Rest_Api.php` | REST endpoint for alt text generation |
-| `src/Dalle_Image_Generator.php` | REST endpoint for DALL-E image generation |
-| `src/Generate_Alt_Text_Cli.php` | WP-CLI command for batch alt text generation |
-| `js/index.js` | Block editor DALL-E integration (featured image panel) |
-| `js/media-alt-text.js` | Media library alt text generation button |
+| File                            | Purpose                                                          |
+| ------------------------------- | ---------------------------------------------------------------- |
+| `better-file-name.php`          | Plugin entry point, bootstraps all classes                       |
+| `src/Settings.php`              | WordPress Settings API integration, option management            |
+| `src/Admin.php`                 | Hook registration, file rename on upload, alt text on attachment |
+| `src/Openai_Wrapper.php`        | OpenAI API communication (GPT-4 Vision, DALL-E)                  |
+| `src/Image.php`                 | Image validation and resizing via WP image editor                |
+| `src/File_Path.php`             | Resolves attachment file paths (local vs production)             |
+| `src/Alt_Text_Rest_Api.php`     | REST endpoint for alt text generation                            |
+| `src/Dalle_Image_Generator.php` | REST endpoint for DALL-E image generation                        |
+| `src/Generate_Alt_Text_Cli.php` | WP-CLI command for batch alt text generation                     |
+| `js/index.js`                   | Block editor DALL-E integration (featured image panel)           |
+| `js/media-alt-text.js`          | Media library alt text generation button                         |

--- a/better-file-name.php
+++ b/better-file-name.php
@@ -27,6 +27,12 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }
 
+// Load Action Scheduler for async background processing (not autoloaded by Composer).
+$better_file_name_action_scheduler = __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
+if ( file_exists( $better_file_name_action_scheduler ) ) {
+	require_once $better_file_name_action_scheduler;
+}
+
 if ( ! class_exists( 'Better_File_Name_Ai\\Settings' ) ) {
 	throw new \Exception( esc_html__( 'Could not find vendor/autoload.php, make sure you ran composer.', 'better-file-name' ) );
 }

--- a/better-file-name.php
+++ b/better-file-name.php
@@ -6,7 +6,7 @@
  * Author:          Utkarsh
  * Author URI:      github.com/patelutkarsh
  * Text Domain:     better-file-name
- * Version:         1.5.0
+ * Version:         1.6.0
  * Requires PHP:    8.1
  * License:         GPL-2.0-or-later
  *

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
 			"phpstan analyse"
 		],
 		"format": "phpcbf --standard=.phpcs.xml.dist"
+	},
+	"require": {
+		"woocommerce/action-scheduler": "^3.9"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,52 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "152ededdc7d2e919e1bc8abaa28ca0b1",
-    "packages": [],
+    "content-hash": "cb10353375865e2f33f44425abbe5c36",
+    "packages": [
+        {
+            "name": "woocommerce/action-scheduler",
+            "version": "3.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/action-scheduler.git",
+                "reference": "c58cdbab17651303d406cd3b22cf9d75c71c986c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/c58cdbab17651303d406cd3b22cf9d75c71c986c",
+                "reference": "c58cdbab17651303d406cd3b22cf9d75c71c986c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5",
+                "woocommerce/woocommerce-sniffs": "0.1.0",
+                "wp-cli/wp-cli": "~2.5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "type": "wordpress-plugin",
+            "extra": {
+                "scripts-description": {
+                    "test": "Run unit tests",
+                    "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "Action Scheduler for WordPress and WooCommerce",
+            "homepage": "https://actionscheduler.org/",
+            "support": {
+                "issues": "https://github.com/woocommerce/action-scheduler/issues",
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.3"
+            },
+            "time": "2025-07-15T09:32:30+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"start": "wp-scripts start js/* --output-path=build",
 		"test:e2e": "wp-scripts test-e2e",
 		"test:unit": "wp-scripts test-unit-js",
-		"wp-env": "wp-env"
+		"wp-env": "wp-env",
+		"process-jobs": "wp-env run cli wp action-scheduler run"
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,16 +1,16 @@
 === Better File Name Ai ===
 Contributors: utkarshpatel
 Donate link:
-Tags: file name generator, alt text, alt text generator, featured image generator, dall-e
+Tags: file name generator, alt text, alt text generator, featured image generator, openai
 Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable tag: 1.5.0
+Stable tag: 1.6.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 This WordPress plugin renames files to be more readable using OpenAI (gpt-4.1-mini) upon upload and generates accessible alt text for images.
 
-Plugin allows generating featured image using dall-e-2 or dall-e-3 API.
+Plugin allows generating featured image using OpenAI's gpt-image-1 API.
 
 Note: This plugin relies on the OpenAI API. Read [terms of service from OpenAI](https://openai.com/policies/terms-of-use) before using this plugin. The plugin sends a low-resolution image to the OpenAI API to generate alt text and file names.
 
@@ -42,7 +42,7 @@ This can take a while depending on the number of images on your site.
 
 == Demo ==
 
-[Demo of featured image generation using Dall-E 2](https://p.utkarsh.workers.dev/demo-TfVNE.mp4)
+[Demo of featured image generation](https://p.utkarsh.workers.dev/demo-TfVNE.mp4)
 
 == Changelog ==
 See [GitHub releases](https://github.com/PatelUtkarsh/better-file-name-ai/releases) for changelog.

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -33,7 +33,7 @@ class Admin {
 			add_action( 'wp_enqueue_media', $this->enqueue_media( ... ) );
 		}
 
-		if ( $this->settings->should_integrate_dall_e() ) {
+		if ( $this->settings->should_integrate_image_generation() ) {
 			add_action( 'enqueue_block_editor_assets', $this->enqueue_scripts( ... ) );
 		}
 	}
@@ -41,7 +41,7 @@ class Admin {
 	public function rename_new_file( array $file ) {
 		$path = $file['tmp_name'];
 
-		$wrapper = new Openai_Wrapper( $this->settings->get_openai_api_key(), $this->settings->get_dell_e_version(), $this->settings->get_vision_model() );
+		$wrapper = new Openai_Wrapper( $this->settings->get_openai_api_key(), $this->settings->get_vision_model() );
 		try {
 			$image = new Image();
 			if ( $image->is_image( $path ) ) {
@@ -77,7 +77,7 @@ class Admin {
 		$uploads = wp_get_upload_dir();
 		$file    = $uploads['basedir'] . '/' . $data['file'];
 
-		$wrapper = new Openai_Wrapper( $this->settings->get_openai_api_key(), $this->settings->get_dell_e_version(), $this->settings->get_vision_model() );
+		$wrapper = new Openai_Wrapper( $this->settings->get_openai_api_key(), $this->settings->get_vision_model() );
 		try {
 			$image = new Image();
 			if ( $image->is_image( $file ) ) {

--- a/src/Alt_Text_Rest_Api.php
+++ b/src/Alt_Text_Rest_Api.php
@@ -49,7 +49,7 @@ class Alt_Text_Rest_Api {
 			return new WP_REST_Response( [ 'error' => 'OpenAI API key not found' ], 404 );
 		}
 
-		$open_ai_wrapper = new Openai_Wrapper( $this->setting->get_openai_api_key(), $this->setting->get_dell_e_version(), $this->setting->get_vision_model() );
+		$open_ai_wrapper = new Openai_Wrapper( $this->setting->get_openai_api_key(), $this->setting->get_vision_model() );
 
 		$post_id = $request->get_param( 'mediaId' );
 

--- a/src/Dalle_Image_Generator.php
+++ b/src/Dalle_Image_Generator.php
@@ -46,7 +46,7 @@ class Dalle_Image_Generator {
 
 		register_rest_route(
 			'better-file-name/v1',
-			'/image-job-status/(?P<job_id>[a-f0-9]+)',
+			'/image-job-status/(?P<job_id>[a-zA-Z0-9]+)',
 			[
 				'methods'             => 'GET',
 				'callback'            => $this->get_job_status( ... ),
@@ -57,7 +57,7 @@ class Dalle_Image_Generator {
 					'job_id' => [
 						'required'          => true,
 						'validate_callback' => function ( $param ) {
-							return is_string( $param ) && preg_match( '/^[a-f0-9]+$/', $param );
+							return is_string( $param ) && preg_match( '/^[a-zA-Z0-9]+$/', $param );
 						},
 					],
 				],

--- a/src/Dalle_Image_Generator.php
+++ b/src/Dalle_Image_Generator.php
@@ -8,12 +8,16 @@ use WP_REST_Response;
 class Dalle_Image_Generator {
 	public Settings $setting;
 
+	const JOB_TRANSIENT_PREFIX = 'bfn_image_job_';
+	const ACTION_HOOK          = 'better_file_name_generate_image';
+
 	public function __construct( Settings $setting ) {
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		add_action( self::ACTION_HOOK, [ $this, 'process_image_generation' ] );
 		$this->setting = $setting;
 	}
 
-	public function register_routes() {
+	public function register_routes(): void {
 		register_rest_route(
 			'better-file-name/v1',
 			'/dalle-generate-image',
@@ -39,52 +43,174 @@ class Dalle_Image_Generator {
 				],
 			]
 		);
+
+		register_rest_route(
+			'better-file-name/v1',
+			'/image-job-status/(?P<job_id>[a-f0-9]+)',
+			[
+				'methods'             => 'GET',
+				'callback'            => $this->get_job_status( ... ),
+				'permission_callback' => function () {
+					return current_user_can( 'upload_files' );
+				},
+				'args'                => [
+					'job_id' => [
+						'required'          => true,
+						'validate_callback' => function ( $param ) {
+							return is_string( $param ) && preg_match( '/^[a-f0-9]+$/', $param );
+						},
+					],
+				],
+			]
+		);
 	}
 
-	public function validate_string( $param, $_request, $_key ) {
+	public function validate_string( $param, $_request, $_key ): bool {
 		unset( $_request, $_key );
 		return is_string( $param );
 	}
 
-	public function generate_image( $request ) {
+	public function generate_image( $request ): WP_REST_Response {
 		$post_title   = $request->get_param( 'postTitle' );
 		$post_content = $request->get_param( 'postContent' );
 		$prompt       = $request->get_param( 'prompt' );
 
-		try {
-			$wrapper       = new Openai_Wrapper( $this->setting->get_openai_api_key(), $this->setting->get_dell_e_version(), $this->setting->get_vision_model() );
-			$url           = $wrapper->generate_image( $prompt, $post_title, $post_content );
-			$attachment_id = $this->save_image_as_attachment( $url );
-		} catch ( \Exception $e ) {
-			return new WP_REST_Response( [ 'error' => $e->getMessage() ], 500 );
+		if ( ! $this->setting->get_openai_api_key() ) {
+			return new WP_REST_Response( [ 'error' => esc_html__( 'OpenAI API key not found', 'better-file-name' ) ], 404 );
 		}
 
-		return new WP_REST_Response( [ 'attachment_id' => $attachment_id ], 200 );
+		$job_id = wp_generate_password( 16, false, false );
+
+		set_transient(
+			self::JOB_TRANSIENT_PREFIX . $job_id,
+			[
+				'status' => 'pending',
+			],
+			HOUR_IN_SECONDS
+		);
+
+		if ( function_exists( 'as_enqueue_async_action' ) ) {
+			as_enqueue_async_action(
+				self::ACTION_HOOK,
+				[
+					[
+						'job_id'       => $job_id,
+						'prompt'       => $prompt,
+						'post_title'   => $post_title,
+						'post_content' => $post_content,
+						'api_key'      => $this->setting->get_openai_api_key(),
+						'model'        => $this->setting->get_image_model(),
+						'quality'      => $this->setting->get_image_quality(),
+						'vision_model' => $this->setting->get_vision_model(),
+					],
+				],
+				'better-file-name'
+			);
+		} else {
+			// Fallback: run synchronously if Action Scheduler is not available.
+			$this->process_image_generation(
+				[
+					'job_id'       => $job_id,
+					'prompt'       => $prompt,
+					'post_title'   => $post_title,
+					'post_content' => $post_content,
+					'api_key'      => $this->setting->get_openai_api_key(),
+					'model'        => $this->setting->get_image_model(),
+					'quality'      => $this->setting->get_image_quality(),
+					'vision_model' => $this->setting->get_vision_model(),
+				]
+			);
+		}
+
+		return new WP_REST_Response( [ 'job_id' => $job_id ], 202 );
 	}
 
-	private function save_image_as_attachment( $image_url ) {
+	public function get_job_status( $request ): WP_REST_Response {
+		$job_id = $request->get_param( 'job_id' );
+		$job    = get_transient( self::JOB_TRANSIENT_PREFIX . $job_id );
+
+		if ( false === $job ) {
+			return new WP_REST_Response( [ 'error' => esc_html__( 'Job not found or expired', 'better-file-name' ) ], 404 );
+		}
+
+		return new WP_REST_Response( $job, 200 );
+	}
+
+	public function process_image_generation( array $args ): void {
+		$job_id = $args['job_id'];
+
+		set_transient(
+			self::JOB_TRANSIENT_PREFIX . $job_id,
+			[
+				'status' => 'processing',
+			],
+			HOUR_IN_SECONDS
+		);
+
+		try {
+			$wrapper    = new Openai_Wrapper( $args['api_key'], $args['vision_model'] );
+			$b64_json   = $wrapper->generate_image( $args['prompt'], $args['post_title'], $args['post_content'], $args['model'], $args['quality'] );
+			$image_data = base64_decode( $b64_json, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+			if ( ! is_string( $image_data ) || '' === $image_data ) {
+				throw new \Exception( esc_html__( 'Failed to decode image data', 'better-file-name' ) );
+			}
+
+			$attachment_id = $this->save_image_data_as_attachment( $image_data );
+
+			set_transient(
+				self::JOB_TRANSIENT_PREFIX . $job_id,
+				[
+					'status'        => 'completed',
+					'attachment_id' => $attachment_id,
+				],
+				HOUR_IN_SECONDS
+			);
+		} catch ( \Exception $e ) {
+			set_transient(
+				self::JOB_TRANSIENT_PREFIX . $job_id,
+				[
+					'status' => 'failed',
+					'error'  => $e->getMessage(),
+				],
+				HOUR_IN_SECONDS
+			);
+		}
+	}
+
+	private function save_image_data_as_attachment( string $image_data ): int {
 		require_once ABSPATH . 'wp-admin/includes/image.php';
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 		require_once ABSPATH . 'wp-admin/includes/media.php';
 
-		$tmp = download_url( $image_url );
+		$upload_dir = wp_upload_dir();
+		$filename   = 'generated-image-' . wp_generate_password( 8, false, false ) . '.jpeg';
+		$file_path  = $upload_dir['path'] . '/' . $filename;
 
-		if ( is_wp_error( $tmp ) ) {
-			throw new \Exception( esc_html( implode( ', ', $tmp->get_error_messages() ) ) );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$bytes_written = file_put_contents( $file_path, $image_data );
+		if ( false === $bytes_written ) {
+			throw new \Exception( esc_html__( 'Failed to write image to uploads directory', 'better-file-name' ) );
 		}
 
-		$file_array = [
-			'name'     => basename( wp_parse_url( $image_url, PHP_URL_PATH ) ),
-			'tmp_name' => $tmp,
+		$attachment = [
+			'post_mime_type' => 'image/jpeg',
+			'post_title'     => sanitize_file_name( $filename ),
+			'post_content'   => '',
+			'post_status'    => 'inherit',
 		];
 
-		$id = media_handle_sideload( $file_array, 0 );
+		$attachment_id = wp_insert_attachment( $attachment, $file_path );
 
-		if ( $id instanceof \WP_Error ) {
-			@unlink( $file_array['tmp_name'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink, WordPress.PHP.NoSilencedErrors.Discouraged
-			throw new \Exception( esc_html( implode( ', ', $id->get_error_messages() ) ) );
+		// @phpstan-ignore-next-line -- wp_insert_attachment can return WP_Error despite PHPDoc stubs.
+		if ( is_wp_error( $attachment_id ) ) {
+			@unlink( $file_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink, WordPress.PHP.NoSilencedErrors.Discouraged
+			throw new \Exception( esc_html( implode( ', ', $attachment_id->get_error_messages() ) ) );
 		}
 
-		return $id;
+		$metadata = wp_generate_attachment_metadata( $attachment_id, $file_path );
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+
+		return $attachment_id;
 	}
 }

--- a/src/Generate_Alt_Text_Cli.php
+++ b/src/Generate_Alt_Text_Cli.php
@@ -58,7 +58,7 @@ class Generate_Alt_Text_Cli {
 		$attachment_ids_chunks = array_chunk( $attachment_ids, 50 );
 		unset( $attachment_ids, $query );
 
-		$open_ai_wrapper = new Openai_Wrapper( $setting->get_openai_api_key(), $setting->get_dell_e_version(), $setting->get_vision_model() );
+		$open_ai_wrapper = new Openai_Wrapper( $setting->get_openai_api_key(), $setting->get_vision_model() );
 
 		$file_path                = new File_Path( $use );
 		$generated_alt_text_count = 0;


### PR DESCRIPTION
## Summary

Replaces deprecated DALL-E 2/3 models (shutdown May 2026) with OpenAI's `gpt-image-1` model family for featured image generation.

## Why async via Action Scheduler

`gpt-image-1` takes 30-90+ seconds on high quality, which exceeds typical PHP `max_execution_time` (30s) and nginx proxy timeouts (60s). Instead of blocking the REST request, the generation is queued via Action Scheduler and processed in a separate background request with its own execution limits.

The frontend polls a status endpoint every 3 seconds until the job completes, showing progress to the user. If Action Scheduler isn't available, it falls back to synchronous execution.

## Key API differences from DALL-E

- Response is `b64_json` (URLs are unsupported) — image data is decoded and saved directly to uploads
- Quality options changed: `low`/`medium`/`high` instead of `standard`/`hd`
- Size options changed: using `1536x1024` (landscape, highest supported)
- 32K char prompt limit vs 1-4K for DALL-E — no more aggressive truncation needed

## Local dev note

WP-Cron loopback requests don't work inside wp-env Docker containers (`localhost:8888` isn't reachable from within the container). Use `pnpm run process-jobs` to manually trigger Action Scheduler after requesting an image generation.